### PR TITLE
Revert "Do not validate pch when -fno-validate-pch is set."

### DIFF
--- a/lib/Serialization/ASTReader.cpp
+++ b/lib/Serialization/ASTReader.cpp
@@ -8710,8 +8710,7 @@ ASTReader::ASTReader(
   bool AllowConfigurationMismatch, bool ValidateSystemInputs,
   bool UseGlobalIndex,
   std::unique_ptr<llvm::Timer> ReadTimer)
-    : Listener(DisableValidation ? nullptr : new PCHValidator(PP, *this)),
-      DeserializationListener(nullptr),
+    : Listener(new PCHValidator(PP, *this)), DeserializationListener(nullptr),
       OwnsDeserializationListener(false), SourceMgr(PP.getSourceManager()),
       FileMgr(PP.getFileManager()), PCHContainerRdr(PCHContainerRdr),
       Diags(PP.getDiagnostics()), SemaObj(nullptr), PP(PP), Context(Context),


### PR DESCRIPTION
This reverts commit 0230cf05a84ecac82e058dc912a2e780b5edef3c.
